### PR TITLE
Custom Partition Cache

### DIFF
--- a/cluster/node.go
+++ b/cluster/node.go
@@ -40,33 +40,35 @@ type Node interface {
 
 // NodeOptions are options for a Node, configuring elements of a Sif cluster
 type NodeOptions struct {
-	Port                  int           // port for this Node to bind to
-	Host                  string        // hostname for this Node to bind to
-	CoordinatorPort       int           // port for the Coordinator Node (potentially identical to Port if this is the Coordinator)
-	CoordinatorHost       string        // [REQUIRED] hostname of the Coordinator Node (potentially identical to Host if this is the Coordinator)
-	NumWorkers            int           // [REQUIRED] the number of Workers to wait for before running the job
-	WorkerJoinTimeout     time.Duration // how long the Coordinator should wait for Workers to join
-	WorkerJoinRetries     int           // how many times a Worker should retry connecting to the Coordinator (at one second intervals)
-	RPCTimeout            time.Duration // timeout for all RPC calls
-	TempDir               string        // location for storing temporary files (primarily persisted partitions)
-	NumInMemoryPartitions int           // the number of partitions to retain in memory before swapping to disk
-	IgnoreRowErrors       bool          // iff true, log row transformation errors instead of crashing immediately
+	Port                     int           // port for this Node to bind to
+	Host                     string        // hostname for this Node to bind to
+	CoordinatorPort          int           // port for the Coordinator Node (potentially identical to Port if this is the Coordinator)
+	CoordinatorHost          string        // [REQUIRED] hostname of the Coordinator Node (potentially identical to Host if this is the Coordinator)
+	NumWorkers               int           // [REQUIRED] the number of Workers to wait for before running the job
+	WorkerJoinTimeout        time.Duration // how long the Coordinator should wait for Workers to join
+	WorkerJoinRetries        int           // how many times a Worker should retry connecting to the Coordinator (at one second intervals)
+	RPCTimeout               time.Duration // timeout for all RPC calls
+	TempDir                  string        // location for storing temporary files (primarily persisted partitions)
+	NumInMemoryPartitions    int           // the number of partitions to retain in memory before swapping to compressed memory
+	CompressedMemoryFraction float32       // the percentage of NumInMemoryPartitions which will be compressed
+	IgnoreRowErrors          bool          // iff true, log row transformation errors instead of crashing immediately
 }
 
 // CloneNodeOptions makes a copy of a NodeOptions
 func CloneNodeOptions(opts *NodeOptions) *NodeOptions {
 	return &NodeOptions{
-		Port:                  opts.Port,
-		Host:                  opts.Host,
-		CoordinatorPort:       opts.CoordinatorPort,
-		CoordinatorHost:       opts.CoordinatorHost,
-		NumWorkers:            opts.NumWorkers,
-		WorkerJoinTimeout:     opts.WorkerJoinTimeout,
-		WorkerJoinRetries:     opts.WorkerJoinRetries,
-		RPCTimeout:            opts.RPCTimeout,
-		TempDir:               opts.TempDir,
-		NumInMemoryPartitions: opts.NumInMemoryPartitions,
-		IgnoreRowErrors:       opts.IgnoreRowErrors,
+		Port:                     opts.Port,
+		Host:                     opts.Host,
+		CoordinatorPort:          opts.CoordinatorPort,
+		CoordinatorHost:          opts.CoordinatorHost,
+		NumWorkers:               opts.NumWorkers,
+		WorkerJoinTimeout:        opts.WorkerJoinTimeout,
+		WorkerJoinRetries:        opts.WorkerJoinRetries,
+		RPCTimeout:               opts.RPCTimeout,
+		TempDir:                  opts.TempDir,
+		NumInMemoryPartitions:    opts.NumInMemoryPartitions,
+		CompressedMemoryFraction: opts.CompressedMemoryFraction,
+		IgnoreRowErrors:          opts.IgnoreRowErrors,
 	}
 }
 
@@ -102,6 +104,9 @@ func ensureDefaultNodeOptionsValues(opts *NodeOptions) {
 	}
 	if opts.NumInMemoryPartitions == 0 {
 		opts.NumInMemoryPartitions = 100 // TODO should this just be a memory limit, and we compute NumInMemoryPartitions ourselves?
+	}
+	if opts.CompressedMemoryFraction == 0 {
+		opts.CompressedMemoryFraction = 0.75 // TODO should this just be a memory limit, and we compute NumCompressedMemoryPartitions ourselves?
 	}
 }
 

--- a/cluster/worker.go
+++ b/cluster/worker.go
@@ -117,10 +117,11 @@ func (w *worker) Start(frame sif.DataFrame) error {
 	}
 	statsTracker := &istats.RunStatistics{}
 	planExecutor := eframe.Optimize().Execute(&itypes.PlanExecutorConfig{
-		TempFilePath:       tmpDir,
-		InMemoryPartitions: inMemoryPartitions,
-		Streaming:          eframe.GetParent().GetDataSource().IsStreaming(),
-		IgnoreRowErrors:    w.opts.IgnoreRowErrors,
+		TempFilePath:             tmpDir,
+		InMemoryPartitions:       inMemoryPartitions,
+		CompressedMemoryFraction: w.opts.CompressedMemoryFraction,
+		Streaming:                eframe.GetParent().GetDataSource().IsStreaming(),
+		IgnoreRowErrors:          w.opts.IgnoreRowErrors,
 	}, statsTracker)
 	statsTracker.Start(planExecutor.GetNumStages())
 	defer statsTracker.Finish()

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,11 @@ module github.com/go-sif/sif
 require (
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/docker v1.13.1 // indirect
+	github.com/docker/docker v1.13.1
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/protobuf v1.3.4
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
-	github.com/hashicorp/golang-lru v0.5.3
 	github.com/klauspost/compress v1.10.5
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/stretchr/testify v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/go-sif/sif
 require (
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/docker v1.13.1 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/protobuf v1.3.4
 	github.com/google/go-cmp v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
-github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/klauspost/compress v1.10.5 h1:7q6vHIqubShURwQz8cQK6yIe/xC3IF0Vm7TGfqjewrc=
 github.com/klauspost/compress v1.10.5/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
+github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=

--- a/internal/dataframe/partition_iterator.go
+++ b/internal/dataframe/partition_iterator.go
@@ -186,9 +186,9 @@ type pTreePartitionIterator struct {
 
 func createPTreeIterator(tree *pTreeRoot, destructive bool) sif.PartitionIterator {
 	if tree == nil {
-		return &pTreePartitionIterator{next: nil, destructive: destructive, endListeners: []func(){}}
+		return &pTreePartitionIterator{next: nil, destructive: destructive, endListeners: []func(){tree.clearCaches}}
 	}
-	return &pTreePartitionIterator{next: tree.firstNode(), destructive: destructive, endListeners: []func(){}}
+	return &pTreePartitionIterator{next: tree.firstNode(), destructive: destructive, endListeners: []func(){tree.clearCaches}}
 }
 
 // OnEnd registers a listener which fires when this iterator runs out of Partitions
@@ -218,11 +218,6 @@ func (tpi *pTreePartitionIterator) NextPartition() (sif.Partition, func(), error
 	if err != nil {
 		return nil, nil, err
 	}
-	toDestroy := tpi.next
 	tpi.next = tpi.next.next // advance iterator
-	if tpi.destructive {
-		toDestroy.unpersist()
-		return part, nil, nil
-	}
 	return part, unlockPartition, nil
 }

--- a/internal/dataframe/partition_tree.go
+++ b/internal/dataframe/partition_tree.go
@@ -480,5 +480,4 @@ func (t *pTreeNode) unpersist() {
 	t.partitionCache.inUse[t.partID] = true
 	t.partitionCache.lruCache.Remove(t.partID)
 	delete(t.partitionCache.inUse, t.partID)
-	// t.cache.lruDisk.Remove(partID)
 }

--- a/internal/dataframe/partition_tree.go
+++ b/internal/dataframe/partition_tree.go
@@ -34,7 +34,7 @@ type pTreeRoot = pTreeNode
 func createPTreeNode(conf *itypes.PlanExecutorConfig, maxRows int, nextStageSchema sif.Schema) *pTreeNode {
 	cache := pcache.NewLRU(&pcache.LRUConfig{
 		Size:               conf.InMemoryPartitions,
-		CompressedFraction: conf.CompressedMemoryPartitions,
+		CompressedFraction: conf.CompressedMemoryFraction,
 		DiskPath:           conf.TempFilePath,
 		Schema:             nextStageSchema,
 	})

--- a/internal/dataframe/partition_tree.go
+++ b/internal/dataframe/partition_tree.go
@@ -180,7 +180,7 @@ func balancedSplitNode(t *pTreeNode, part itypes.ReduceablePartition, hashedKey 
 		// this is where we end up if all the keys are the same
 		return avgKey, nil, err
 	}
-	log.Printf("Splitting partition %s", t.partID)
+	// log.Printf("Splitting partition %s", t.partID)
 	t.k = avgKey
 	t.left = &pTreeNode{
 		k:               0,
@@ -225,7 +225,7 @@ func balancedSplitNode(t *pTreeNode, part itypes.ReduceablePartition, hashedKey 
 // current pTreeNode all have the same key, we instead store
 // the partition in the "center" of the parent, or ourselves
 func (t *pTreeNode) rotateToCenter(avgKey uint64) (*pTreeNode, error) {
-	log.Printf("Rotating partition %s to center", t.partID)
+	// log.Printf("Rotating partition %s to center", t.partID)
 	// if our parent's avgKey is identical to all of the rows in this
 	// pTreeNode, then this pTreeNode belongs in the parents' center chain
 	if t.parent != nil && t.parent.k == avgKey {
@@ -328,7 +328,7 @@ func (t *pTreeNode) loadPartition() (itypes.ReduceablePartition, func(), error) 
 		return nil, nil, err
 	}
 	return part, func() {
-		log.Printf("Returning partition %s to cache", t.partID)
+		// log.Printf("Returning partition %s to cache", t.partID)
 		// we only add the partition to the LRU cache when it's finished being
 		// operated on to make sure it isn't swapped to disk while it's in use
 		t.partitionCache.Add(t.partID, part)

--- a/internal/dataframe/partition_tree.go
+++ b/internal/dataframe/partition_tree.go
@@ -1,30 +1,16 @@
 package dataframe
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
-	"path"
 
 	xxhash "github.com/cespare/xxhash/v2"
 	"github.com/go-sif/sif"
 	"github.com/go-sif/sif/errors"
 	"github.com/go-sif/sif/internal/partition"
+	"github.com/go-sif/sif/internal/pcache"
 	itypes "github.com/go-sif/sif/internal/types"
 	"github.com/go-sif/sif/internal/util"
-	lru "github.com/hashicorp/golang-lru"
-	"github.com/klauspost/compress/zstd"
 )
-
-type pTreeCache struct {
-	tempDir      string
-	compressor   *zstd.Encoder
-	decompressor *zstd.Decoder
-	lruCache     *lru.Cache
-	inUse        map[string]bool
-}
 
 // pTreeNode is a node of a tree that builds, sorts and organizes keyed partitions. NOT THREAD SAFE.
 type pTreeNode struct {
@@ -38,7 +24,7 @@ type pTreeNode struct {
 	prev            *pTreeNode // btree-like link between leaves
 	next            *pTreeNode // btree-like link between leaves
 	parent          *pTreeNode
-	partitionCache  *pTreeCache
+	partitionCache  pcache.PartitionCache
 }
 
 // pTreeRoot is an alias for pTreeNode representing the root node of a pTree
@@ -46,59 +32,24 @@ type pTreeRoot = pTreeNode
 
 // createPTreeNode creates a new pTree with a limit on Partition size and a given shared Schema
 func createPTreeNode(conf *itypes.PlanExecutorConfig, maxRows int, nextStageSchema sif.Schema) *pTreeNode {
-	// TODO the minimum number of in-memory partitions must be greater than the number of partitions
-	// which are used concurrently, such as in a split(). Otherwise a partition
-	// which is being used may be evicted to disk and further writes to it would not be saved.
-	if conf.InMemoryPartitions < 5 {
-		log.Fatalf("Partition Trees must be capable of holding at least 5 Partitions in memory concurrently.")
-	}
-	// init compressor/decompressor
-	compressor, err := zstd.NewWriter(new(bytes.Buffer), zstd.WithEncoderLevel(zstd.SpeedFastest))
-	if err != nil {
-		log.Fatalf("Unable to initialize compressor: %e", err)
-	}
-	decompressor, err := zstd.NewReader(new(bytes.Buffer))
-	if err != nil {
-		log.Fatalf("Unable to initialize decompressor: %e", err)
-	}
-	// setup partition cache
-	partitionCache := &pTreeCache{
-		compressor:   compressor,
-		decompressor: decompressor,
-		tempDir:      conf.TempFilePath,
-		inUse:        make(map[string]bool),
-	}
-	memLru, err := lru.NewWithEvict(conf.InMemoryPartitions, func(key interface{}, value interface{}) {
-		partID, ok := key.(string)
-		if !ok {
-			log.Fatalf("Unable to sync partition %s to disk due to key casting issue", key)
-		}
-		// Calls to Remove() don't swap to disk if the partition is in use
-		if partitionCache.inUse[partID] {
-			return
-		}
-		part, ok := value.(itypes.ReduceablePartition)
-		if !ok {
-			log.Fatalf("Unable to sync partition %s to disk due to value casting issue", value)
-		}
-		onPartitionEvict(partitionCache, partID, part)
+	cache := pcache.NewLRU(&pcache.LRUConfig{
+		Size:               conf.InMemoryPartitions,
+		CompressedFraction: conf.CompressedMemoryPartitions,
+		DiskPath:           conf.TempFilePath,
+		Schema:             nextStageSchema,
 	})
-	if err != nil {
-		log.Fatalf("Unable to initialize lru cache for partitions: %e", err)
-	}
-	partitionCache.lruCache = memLru
 	// create initial partition for root node
 	part := partition.CreateReduceablePartition(maxRows, nextStageSchema)
 	part.KeyRows(nil)
 	partID := part.ID()
-	memLru.Add(partID, part)
+	cache.Add(partID, part)
 	// return root node
 	return &pTreeNode{
 		k:               0,
 		partID:          partID,
 		maxRows:         part.GetMaxRows(),
 		nextStageSchema: nextStageSchema,
-		partitionCache:  partitionCache,
+		partitionCache:  cache,
 	}
 }
 
@@ -259,8 +210,8 @@ func balancedSplitNode(t *pTreeNode, part itypes.ReduceablePartition, hashedKey 
 	t.prev = nil  // non-leaf nodes don't have horizontal links
 	t.next = nil  // non-leaf nodes don't have horizontal links
 	// add left and right to front of "visited" queue
-	t.partitionCache.lruCache.Add(t.left.partID, lp)
-	t.partitionCache.lruCache.Add(t.right.partID, rp)
+	t.partitionCache.Add(t.left.partID, lp)
+	t.partitionCache.Add(t.right.partID, rp)
 	// tell the caller where to go next
 	if hashedKey < t.k {
 		return avgKey, t.left, nil
@@ -306,7 +257,7 @@ func (t *pTreeNode) rotateToCenter(avgKey uint64) (*pTreeNode, error) {
 			t.parent.right.next.prev = t.parent.right
 		}
 		// add new partition to front of "visited" queue
-		t.partitionCache.lruCache.Add(rp.ID(), rp)
+		t.partitionCache.Add(rp.ID(), rp)
 		// we know we got into this situation by adding a row with key == avgKey. These
 		// rows now belong in t.parent.right, so return that as the "next" node to recurse on
 		return t.parent.right, nil
@@ -352,8 +303,8 @@ func (t *pTreeNode) rotateToCenter(avgKey uint64) (*pTreeNode, error) {
 		t.right.next.prev = t.right
 	}
 	// add new partitions to front of "visited" queue
-	t.partitionCache.lruCache.Add(lp.ID(), lp)
-	t.partitionCache.lruCache.Add(rp.ID(), rp)
+	t.partitionCache.Add(lp.ID(), lp)
+	t.partitionCache.Add(rp.ID(), rp)
 	// update links for center chain
 	t.center.next = t.right
 	t.center.prev = t.left
@@ -370,92 +321,16 @@ func (t *pTreeNode) loadPartition() (itypes.ReduceablePartition, func(), error) 
 	if len(t.partID) == 0 {
 		return nil, nil, fmt.Errorf("Partition tree node does not have an associated partition\n %s", util.GetTrace())
 	}
-	part, ok := t.partitionCache.lruCache.Get(t.partID)
-	if !ok {
-		// log.Printf("Loading partition %s from disk", t.partID)
-		tempFilePath := path.Join(t.partitionCache.tempDir, t.partID)
-		f, err := os.Open(tempFilePath)
-		if err != nil {
-			return nil, nil, fmt.Errorf("Unable to load disk-swapped partition %s: %e", tempFilePath, err)
-		}
-		defer func() {
-			err := f.Close()
-			if err != nil {
-				log.Printf("Unable to close file %s", tempFilePath)
-			}
-			err = os.Remove(tempFilePath)
-			if err != nil {
-				log.Printf("Unable to remove file %s", tempFilePath)
-			}
-		}()
-		err = t.partitionCache.decompressor.Reset(f)
-		if err != nil {
-			return nil, nil, fmt.Errorf("Unable to decompress disk-swapped partition %s: %e", tempFilePath, err)
-		}
-		buff, err := ioutil.ReadAll(t.partitionCache.decompressor)
-		if err != nil {
-			return nil, nil, fmt.Errorf("Unable to decompress disk-swapped partition %s: %e", tempFilePath, err)
-		}
-		if t.nextStageSchema == nil {
-			panic(fmt.Errorf("Next stage schema was nil"))
-		}
-		part, err := partition.FromBytes(buff, t.nextStageSchema)
-		if err != nil {
-			return nil, nil, err
-		}
-		return part, func() {
-			// log.Printf("Returning partition %s to cache", t.partID)
-			// we only add the partition to the LRU cache when it's finished being
-			// operated on to make sure it isn't swapped to disk while it's in use
-			delete(t.partitionCache.inUse, t.partID)
-			t.partitionCache.lruCache.Add(t.partID, part)
-		}, nil
+	part, err := t.partitionCache.Get(t.partID)
+	if err != nil {
+		return nil, nil, err
 	}
-	t.partitionCache.inUse[t.partID] = true
-	t.partitionCache.lruCache.Remove(t.partID)
-	rpart := part.(itypes.ReduceablePartition)
-	// log.Printf("Loading partition %s from cache", t.partID)
-	return rpart, func() {
+	return part, func() {
 		// log.Printf("Returning partition %s to cache", t.partID)
 		// we only add the partition to the LRU cache when it's finished being
 		// operated on to make sure it isn't swapped to disk while it's in use
-		delete(t.partitionCache.inUse, t.partID)
-		t.partitionCache.lruCache.Add(t.partID, rpart)
+		t.partitionCache.Add(t.partID, part)
 	}, nil
-}
-
-func onPartitionEvict(cache *pTreeCache, partID string, part itypes.ReduceablePartition) {
-	// log.Printf("Swapping partition %s to disk", part.ID())
-	buff, err := part.ToBytes()
-	if err != nil {
-		log.Fatalf("Unable to convert partition to buffer %s", err)
-	}
-
-	tempFilePath := path.Join(cache.tempDir, part.ID())
-	f, err := os.Create(tempFilePath)
-	defer f.Close()
-	if err != nil {
-		log.Fatalf("Unable to create temporary file for partition %s", err)
-	}
-	defer func() {
-		err = f.Sync()
-		if err != nil {
-			log.Printf("Unable to sync file %s", tempFilePath)
-		}
-		err := f.Close()
-		if err != nil {
-			log.Printf("Unable to close file %s", tempFilePath)
-		}
-	}()
-	cache.compressor.Reset(f)
-	_, err = cache.compressor.Write(buff)
-	if err != nil {
-		log.Fatalf("Unable to write compressed data for partition %s", err)
-	}
-	err = cache.compressor.Close()
-	if err != nil {
-		log.Fatalf("Unable to write compressed data for partition %s", err)
-	}
 }
 
 func (t *pTreeNode) findPartition(hashedKey uint64) *pTreeNode {
@@ -476,8 +351,6 @@ func (t *pTreeRoot) firstNode() *pTreeNode {
 	return first
 }
 
-func (t *pTreeNode) unpersist() {
-	t.partitionCache.inUse[t.partID] = true
-	t.partitionCache.lruCache.Remove(t.partID)
-	delete(t.partitionCache.inUse, t.partID)
+func (t *pTreeNode) clearCaches() {
+	t.partitionCache.Destroy()
 }

--- a/internal/dataframe/partition_tree.go
+++ b/internal/dataframe/partition_tree.go
@@ -164,15 +164,7 @@ func (t *pTreeRoot) doMergeRow(tempRow sif.Row, row sif.Row, hashedKey uint64, r
 		return err
 	} else {
 		// If the actual key already exists in the partition, merge into row
-		partition.PopulateTempRow(
-			tempRow,
-			part.ID(),
-			part.GetRowMeta(idx),
-			part.GetRowData(idx),
-			part.GetVarRowData(idx),
-			part.GetSerializedVarRowData(idx),
-			part.GetSchema(),
-		)
+		part.PopulateTempRow(tempRow, idx)
 		return reducefn(tempRow, row)
 	}
 	return nil
@@ -188,7 +180,7 @@ func balancedSplitNode(t *pTreeNode, part itypes.ReduceablePartition, hashedKey 
 		// this is where we end up if all the keys are the same
 		return avgKey, nil, err
 	}
-	// log.Printf("Splitting partition %s", t.partID)
+	log.Printf("Splitting partition %s", t.partID)
 	t.k = avgKey
 	t.left = &pTreeNode{
 		k:               0,
@@ -233,7 +225,7 @@ func balancedSplitNode(t *pTreeNode, part itypes.ReduceablePartition, hashedKey 
 // current pTreeNode all have the same key, we instead store
 // the partition in the "center" of the parent, or ourselves
 func (t *pTreeNode) rotateToCenter(avgKey uint64) (*pTreeNode, error) {
-	// log.Printf("Rotating partition %s to center", t.partID)
+	log.Printf("Rotating partition %s to center", t.partID)
 	// if our parent's avgKey is identical to all of the rows in this
 	// pTreeNode, then this pTreeNode belongs in the parents' center chain
 	if t.parent != nil && t.parent.k == avgKey {

--- a/internal/dataframe/partition_tree_test.go
+++ b/internal/dataframe/partition_tree_test.go
@@ -3,6 +3,7 @@ package dataframe
 import (
 	"math/rand"
 	"os"
+	"sync"
 	"testing"
 
 	xxhash "github.com/cespare/xxhash/v2"
@@ -68,7 +69,7 @@ func TestMergeRow(t *testing.T) {
 	defer root.clearCaches()
 
 	// add the first row
-	row := partition.CreateRow("part-0", []byte{0, 0}, []byte{1, 1}, make(map[string]interface{}), make(map[string][]byte), schema)
+	row := partition.CreateRow("part-0", &sync.Mutex{}, []byte{0, 0}, []byte{1, 1}, make(map[string]interface{}), make(map[string][]byte), schema)
 	err := root.mergeRow(partition.CreateTempRow(), row, pTreeTestKeyer, pTreeTestReducer)
 	require.Nil(t, err)
 	require.Greater(t, len(root.partID), 0)
@@ -84,7 +85,7 @@ func TestMergeRow(t *testing.T) {
 	unlockPartition()
 
 	// add another distinct row
-	row = partition.CreateRow("part-0", []byte{0, 0}, []byte{2, 1}, make(map[string]interface{}), make(map[string][]byte), schema)
+	row = partition.CreateRow("part-0", &sync.Mutex{}, []byte{0, 0}, []byte{2, 1}, make(map[string]interface{}), make(map[string][]byte), schema)
 	err = root.mergeRow(partition.CreateTempRow(), row, pTreeTestKeyer, pTreeTestReducer)
 	require.Nil(t, err)
 	require.Greater(t, len(root.partID), 0)
@@ -100,7 +101,7 @@ func TestMergeRow(t *testing.T) {
 	unlockPartition()
 
 	// add a merge row
-	row = partition.CreateRow("part-0", []byte{0, 0}, []byte{1, 2}, make(map[string]interface{}), make(map[string][]byte), schema)
+	row = partition.CreateRow("part-0", &sync.Mutex{}, []byte{0, 0}, []byte{1, 2}, make(map[string]interface{}), make(map[string][]byte), schema)
 	err = root.mergeRow(partition.CreateTempRow(), row, pTreeTestKeyer, pTreeTestReducer)
 	require.Nil(t, err)
 	require.Greater(t, len(root.partID), 0)
@@ -146,7 +147,7 @@ func TestMergeRowWithSplit(t *testing.T) {
 
 	tempRow := partition.CreateTempRow()
 	for i := byte(0); i < byte(6); i++ {
-		row := partition.CreateRow("part-0", []byte{0, 0}, []byte{i, 1}, make(map[string]interface{}), make(map[string][]byte), schema)
+		row := partition.CreateRow("part-0", &sync.Mutex{}, []byte{0, 0}, []byte{i, 1}, make(map[string]interface{}), make(map[string][]byte), schema)
 		err := root.mergeRow(tempRow, row, pTreeTestKeyer, pTreeTestReducer)
 		require.Nil(t, err)
 	}
@@ -174,7 +175,7 @@ func TestMergeRowWithRotate(t *testing.T) {
 	defer root.clearCaches()
 	tempRow := partition.CreateTempRow()
 	for i := 0; i < 8; i++ {
-		row := partition.CreateRow("part-0", []byte{0, 0}, []byte{1, 1}, make(map[string]interface{}), make(map[string][]byte), schema)
+		row := partition.CreateRow("part-0", &sync.Mutex{}, []byte{0, 0}, []byte{1, 1}, make(map[string]interface{}), make(map[string][]byte), schema)
 		err := root.mergeRow(tempRow, row, pTreeTestKeyer, nil)
 		require.Nil(t, err)
 	}
@@ -195,7 +196,7 @@ func TestMergeRowWithRotate(t *testing.T) {
 	require.Equal(t, 8, numTreeRows)
 	// add more rows with a different key, and check that they're sorted properly
 	for i := 0; i < 8; i++ {
-		row := partition.CreateRow("part-0", []byte{0, 0}, []byte{2, 1}, make(map[string]interface{}), make(map[string][]byte), schema)
+		row := partition.CreateRow("part-0", &sync.Mutex{}, []byte{0, 0}, []byte{2, 1}, make(map[string]interface{}), make(map[string][]byte), schema)
 		err := root.mergeRow(tempRow, row, pTreeTestKeyer, nil)
 		require.Nil(t, err)
 	}
@@ -239,7 +240,7 @@ func TestDiskSwap(t *testing.T) {
 	tempRow := partition.CreateTempRow()
 	// store enough rows that we have 20 partitions, so some get swapped to disk
 	for i := uint32(0); i < 40; i++ {
-		row := partition.CreateRow("part-0", []byte{0, 0}, make([]byte, 8), make(map[string]interface{}), make(map[string][]byte), schema)
+		row := partition.CreateRow("part-0", &sync.Mutex{}, []byte{0, 0}, make([]byte, 8), make(map[string]interface{}), make(map[string][]byte), schema)
 		require.Nil(t, row.SetUint32("key", i))
 		require.Nil(t, row.SetUint32("val", i))
 		err := root.mergeRow(tempRow, row, transform.KeyColumns("key"), reduceFn)
@@ -247,7 +248,7 @@ func TestDiskSwap(t *testing.T) {
 	}
 	// Now do it again, forcing those partitions to be reloaded
 	for i := uint32(0); i < 40; i++ {
-		row := partition.CreateRow("part-0", []byte{0, 0}, make([]byte, 8), make(map[string]interface{}), make(map[string][]byte), schema)
+		row := partition.CreateRow("part-0", &sync.Mutex{}, []byte{0, 0}, make([]byte, 8), make(map[string]interface{}), make(map[string][]byte), schema)
 		require.Nil(t, row.SetUint32("key", i))
 		require.Nil(t, row.SetUint32("val", i))
 		err := root.mergeRow(tempRow, row, transform.KeyColumns("key"), reduceFn)
@@ -278,7 +279,7 @@ func TestPartitionIterationDuringReduction(t *testing.T) {
 	rowCount := 25
 	// store a bunch of random rows, so some partitions get swapped to disk
 	for i := 0; i < rowCount; i++ {
-		row := partition.CreateRow("part-0", []byte{0, 0}, make([]byte, 8), make(map[string]interface{}), make(map[string][]byte), schema)
+		row := partition.CreateRow("part-0", &sync.Mutex{}, []byte{0, 0}, make([]byte, 8), make(map[string]interface{}), make(map[string][]byte), schema)
 		require.Nil(t, row.SetUint32("key", uint32(i)))
 		require.Nil(t, row.SetUint32("val", rand.Uint32()))
 		err := root.mergeRow(tempRow, row, transform.KeyColumns("key"), reduceFn)
@@ -317,7 +318,7 @@ func TestPartitionIterationDuringRepartition(t *testing.T) {
 	rowCount := 200
 	// store a bunch of random rows, so some partitions get swapped to disk
 	for i := 0; i < rowCount; i++ {
-		row := partition.CreateRow("part-0", []byte{0, 0}, make([]byte, 8), make(map[string]interface{}), make(map[string][]byte), schema)
+		row := partition.CreateRow("part-0", &sync.Mutex{}, []byte{0, 0}, make([]byte, 8), make(map[string]interface{}), make(map[string][]byte), schema)
 		require.Nil(t, row.SetUint32("key", uint32(i/5))) // make sure we have duplicate keys
 		require.Nil(t, row.SetUint32("val", rand.Uint32()))
 		err := root.mergeRow(tempRow, row, transform.KeyColumns("key"), nil)

--- a/internal/partition/partition-reduceable.go
+++ b/internal/partition/partition-reduceable.go
@@ -29,7 +29,6 @@ func CreateKeyedReduceablePartition(maxRows int, schema sif.Schema) itypes.Reduc
 func (p *partitionImpl) PopulateTempRow(tempRow sif.Row, idx int) {
 	r := tempRow.(*rowImpl)
 	r.partID = p.ID()
-	r.partVarDataLock = &p.varDataLock
 	r.meta = p.GetRowMeta(idx)
 	r.data = p.GetRowData(idx)
 	r.varData = p.GetVarRowData(idx)

--- a/internal/partition/row.go
+++ b/internal/partition/row.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 
 	time "time"
 
@@ -23,6 +24,7 @@ const (
 // getter and setter methods to retrieve, manipulate and store data
 type rowImpl struct {
 	partID            string
+	partVarDataLock   *sync.Mutex
 	meta              []byte
 	data              []byte                 // likely a slice of a partition array
 	varData           map[string]interface{} // variable-length data
@@ -31,24 +33,13 @@ type rowImpl struct {
 }
 
 // CreateRow builds a new row from individual internal components
-func CreateRow(partID string, meta []byte, data []byte, varData map[string]interface{}, serializedVarData map[string][]byte, schema sif.Schema) sif.Row {
-	return &rowImpl{partID: partID, meta: meta, data: data, varData: varData, serializedVarData: serializedVarData, schema: schema}
+func CreateRow(partID string, partVarDataLock *sync.Mutex, meta []byte, data []byte, varData map[string]interface{}, serializedVarData map[string][]byte, schema sif.Schema) sif.Row {
+	return &rowImpl{partID: partID, partVarDataLock: partVarDataLock, meta: meta, data: data, varData: varData, serializedVarData: serializedVarData, schema: schema}
 }
 
 // CreateTempRow builds an empty row struct which cannot be used until passed to a function which populates it with data
 func CreateTempRow() sif.Row {
 	return &rowImpl{}
-}
-
-// PopulateTempRow overwrites the internal data of a temporary row
-func PopulateTempRow(row sif.Row, partID string, meta []byte, data []byte, varData map[string]interface{}, serializedVarData map[string][]byte, schema sif.Schema) {
-	r := row.(*rowImpl)
-	r.partID = partID
-	r.meta = meta
-	r.data = data
-	r.varData = varData
-	r.serializedVarData = serializedVarData
-	r.schema = schema
 }
 
 // Schema returns a read-only copy of the schema for a row
@@ -364,6 +355,8 @@ func (r *rowImpl) GetString(colName string) (string, error) {
 
 // GetVarCustomData retrieves variable-length data of a custom type from the column with the given name
 func (r *rowImpl) GetVarCustomData(colName string) (interface{}, error) {
+	r.partVarDataLock.Lock()
+	defer r.partVarDataLock.Unlock()
 	offset, err := r.schema.GetOffset(colName)
 	if err != nil {
 		return nil, err
@@ -380,11 +373,16 @@ func (r *rowImpl) GetVarCustomData(colName string) (interface{}, error) {
 			delete(r.serializedVarData, colName)
 			return nil, errors.NilValueError{Name: colName}
 		}
+		// serialized data should never be empty
+		if len(ser) == 0 {
+			return nil, fmt.Errorf("Serialized column data for column %s in partition %s should not be zero-length", colName, r.partID)
+		}
 		deser, err := vcol.Deserialize(ser)
 		if err != nil {
-			return nil, fmt.Errorf("Error deserializing variable-length column data for column %s: %w", colName, err)
+			return nil, fmt.Errorf("Error deserializing variable-length column data for column %s in partition %s: %w", colName, r.partID, err)
 		}
 		r.varData[colName] = deser
+		// log.Printf("Deserializing column %s in partition %s", colName, r.partID)
 		delete(r.serializedVarData, colName)
 		return r.varData[colName], nil
 	}
@@ -609,5 +607,6 @@ func (r *rowImpl) Repack(newSchema sif.Schema) (sif.Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &rowImpl{r.partID, meta, buff, varData, serializedVarData, newSchema}, nil
+	// no partID or lock, because this new row belongs to no partition
+	return &rowImpl{"", &sync.Mutex{}, meta, buff, varData, serializedVarData, newSchema}, nil
 }

--- a/internal/pcache/cache.go
+++ b/internal/pcache/cache.go
@@ -148,6 +148,7 @@ func (c *lru) Add(key string, value itypes.ReduceablePartition) {
 func (c *lru) Get(key string) (value itypes.ReduceablePartition, err error) {
 	c.plocks.Lock(key)
 	defer c.plocks.Unlock(key)
+	log.Printf("Loading partition %s...", key)
 	value, err = c.getFromCache(key)
 	if err != nil {
 		value, err = c.getFromCompressedCache(key)

--- a/internal/pcache/cache.go
+++ b/internal/pcache/cache.go
@@ -1,0 +1,230 @@
+package pcache
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/docker/docker/pkg/locker"
+	"github.com/go-sif/sif"
+	"github.com/go-sif/sif/internal/partition"
+	itypes "github.com/go-sif/sif/internal/types"
+	"github.com/klauspost/compress/zstd"
+)
+
+// lru is an LRU cache for Partitions
+type lru struct {
+	config                     *LRUConfig
+	compressor                 *zstd.Encoder
+	decompressor               *zstd.Decoder
+	plocks                     *locker.Locker
+	pmapLock                   sync.Mutex
+	pmap                       map[string]*list.Element
+	compressedPmapLock         sync.Mutex
+	compressedPmap             map[string]*list.Element
+	recentUncompressedListLock sync.Mutex
+	recentUncompressedList     *list.List // back is oldest, front is newest
+	recentCompressedListLock   sync.Mutex
+	recentCompressedList       *list.List // back is oldest, front is newest
+	maxUncompressed            int
+	maxCompressed              int
+	toCompressed               chan *cachedPartition
+	toDisk                     chan *cachedCompressedPartition
+}
+
+type cachedPartition struct {
+	key   string
+	value itypes.ReduceablePartition
+}
+
+type cachedCompressedPartition struct {
+	key   string
+	value []byte
+}
+
+// LRUConfig configures an LRU PartitionCache
+type LRUConfig struct {
+	Size               int
+	CompressedFraction float32
+	DiskPath           string
+	Schema             sif.Schema
+}
+
+// NewLRU produces an LRU PartitionCache
+func NewLRU(config *LRUConfig) PartitionCache {
+	if config.Size < 5 {
+		log.Panicf("LRUConfig.Size %d must be greater than 5", config.Size)
+	}
+	if config.CompressedFraction < 0 || config.CompressedFraction > 1 {
+		log.Panicf("LRUConfig.CompressedFraction %f must be between 0 and 1", config.CompressedFraction)
+	}
+	if config.Schema == nil {
+		log.Panicf("Next stage schema was nil")
+	}
+	maxUncompressed := int(float32(config.Size) * (1 - config.CompressedFraction))
+	maxCompressed := config.Size - maxUncompressed
+	transferChanSize := config.Size / 100
+	if transferChanSize < 5 {
+		transferChanSize = 5
+	}
+	// init compressor/decompressor
+	compressor, err := zstd.NewWriter(new(bytes.Buffer), zstd.WithEncoderLevel(zstd.SpeedFastest))
+	if err != nil {
+		log.Fatalf("Unable to initialize compressor: %e", err)
+	}
+	decompressor, err := zstd.NewReader(new(bytes.Buffer))
+	if err != nil {
+		log.Fatalf("Unable to initialize decompressor: %e", err)
+	}
+	return &lru{
+		compressor:             compressor,
+		decompressor:           decompressor,
+		config:                 config,
+		plocks:                 locker.New(),
+		pmap:                   make(map[string]*list.Element),
+		compressedPmap:         make(map[string]*list.Element),
+		recentUncompressedList: list.New(),
+		recentCompressedList:   list.New(),
+		maxUncompressed:        maxUncompressed,
+		maxCompressed:          maxCompressed,
+		toCompressed:           make(chan *cachedPartition, transferChanSize),
+		toDisk:                 make(chan *cachedCompressedPartition, transferChanSize),
+	}
+}
+
+func (c *lru) Destroy() {
+	close(c.toCompressed)
+	close(c.toDisk)
+	panic("not implemented") // TODO: Implement
+}
+
+func (c *lru) Add(key string, value itypes.ReduceablePartition) {
+	c.plocks.Lock(key)
+	defer c.plocks.Unlock(key)
+
+	// update the recent list
+	c.recentUncompressedListLock.Lock()
+	e := c.recentUncompressedList.PushFront(&cachedPartition{
+		key:   key,
+		value: value,
+	})
+	defer c.recentUncompressedListLock.Unlock()
+
+	// update the uncompressed cache
+	c.pmapLock.Lock()
+	c.pmap[key] = e
+	defer c.pmapLock.Unlock()
+
+	// if we're full, it can only be because the uncompressed
+	// cache has grown, so let's just check that one
+	if c.recentUncompressedList.Len() > c.maxUncompressed {
+		toRemove := c.recentCompressedList.Back()
+		c.recentUncompressedList.Remove(toRemove)
+		c.toCompressed <- toRemove.Value.(*cachedPartition)
+		go c.evictToCompressedMemory()
+	}
+}
+
+// Get removes the partition from the caches and returns it, if present. Returns an error otherwise.
+func (c *lru) Get(key string) (value itypes.ReduceablePartition, err error) {
+	value, err = c.getFromCache(key)
+	if err != nil {
+		value, err = c.getFromCompressedCache(key)
+		if err != nil {
+			value, err = c.getFromDisk(key)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return
+}
+
+// getFromCache removes the partition from the uncompressed cache and returns it, if present
+func (c *lru) getFromCache(key string) (value itypes.ReduceablePartition, err error) {
+	c.pmapLock.Lock()
+	defer c.pmapLock.Unlock()
+	ve, ok := c.pmap[key]
+	if ok {
+		delete(c.pmap, key)
+		c.recentUncompressedListLock.Lock()
+		c.recentUncompressedList.Remove(ve)
+		c.recentUncompressedListLock.Unlock()
+		return ve.Value.(*cachedPartition).value, nil
+	}
+	return nil, fmt.Errorf("Partition %s is not in the cache", key)
+}
+
+// getFromCache removes the partition from the compressed cache and returns it, if present
+func (c *lru) getFromCompressedCache(key string) (value itypes.ReduceablePartition, err error) {
+	c.compressedPmapLock.Lock()
+	defer c.compressedPmapLock.Unlock()
+	cve, cok := c.compressedPmap[key]
+	if cok {
+		delete(c.compressedPmap, key)
+		c.recentCompressedListLock.Lock()
+		c.recentCompressedList.Remove(cve)
+		c.recentCompressedListLock.Unlock()
+		bf := bytes.NewReader(cve.Value.([]byte))
+		err := c.decompressor.Reset(bf)
+		if err != nil {
+			panic(err)
+		}
+		buff, err := ioutil.ReadAll(c.decompressor)
+		decompressedPart, err := partition.FromBytes(buff, c.config.Schema)
+		if err != nil {
+			panic(err)
+		}
+		return decompressedPart, nil
+	}
+	return nil, fmt.Errorf("Partition %s is not in the cache", key)
+}
+
+// getFromCache removes the partition from the disk cache and returns it, if present
+func (c *lru) getFromDisk(key string) (value itypes.ReduceablePartition, err error) {
+	tempFilePath := path.Join(c.config.DiskPath, key)
+	f, err := os.Open(tempFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to load disk-swapped partition %s: %e", tempFilePath, err)
+	}
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			log.Printf("Unable to close file %s", tempFilePath)
+		}
+		err = os.Remove(tempFilePath)
+		if err != nil {
+			log.Printf("Unable to remove file %s", tempFilePath)
+		}
+	}()
+	err = c.decompressor.Reset(f)
+	if err != nil {
+		log.Panicf("Unable to decompress disk-swapped partition %s: %e", tempFilePath, err)
+	}
+	buff, err := ioutil.ReadAll(c.decompressor)
+	if err != nil {
+		log.Panicf("Unable to decompress disk-swapped partition %s: %e", tempFilePath, err)
+	}
+	part, err := partition.FromBytes(buff, c.config.Schema)
+	if err != nil {
+		panic(err)
+	}
+	return part, nil
+}
+
+func (c *lru) Resize(size int) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (c *lru) evictToCompressedMemory() {
+	panic("not implemented") // TODO: Implement
+}
+
+func (c *lru) evictToDisk() {
+	panic("not implemented") // TODO: Implement
+}

--- a/internal/pcache/cache.go
+++ b/internal/pcache/cache.go
@@ -117,7 +117,7 @@ func (c *lru) Add(key string, value itypes.ReduceablePartition) {
 	c.plocks.Lock(key)
 	defer c.plocks.Unlock(key)
 
-	log.Printf("Adding partition %s to uncompressed memory", key)
+	// log.Printf("Adding partition %s to uncompressed memory", key)
 
 	// update the recent list
 	c.recentUncompressedListLock.Lock()
@@ -148,7 +148,7 @@ func (c *lru) Add(key string, value itypes.ReduceablePartition) {
 func (c *lru) Get(key string) (value itypes.ReduceablePartition, err error) {
 	c.plocks.Lock(key)
 	defer c.plocks.Unlock(key)
-	log.Printf("Loading partition %s...", key)
+	// log.Printf("Loading partition %s...", key)
 	value, err = c.getFromCache(key)
 	if err != nil {
 		value, err = c.getFromCompressedCache(key)
@@ -172,7 +172,7 @@ func (c *lru) getFromCache(key string) (value itypes.ReduceablePartition, err er
 		c.recentUncompressedListLock.Lock()
 		c.recentUncompressedList.Remove(ve)
 		c.recentUncompressedListLock.Unlock()
-		log.Printf("Loaded partition %s from uncompressed memory", key)
+		// log.Printf("Loaded partition %s from uncompressed memory", key)
 		return ve.Value.(*cachedPartition).value, nil
 	}
 	return nil, fmt.Errorf("Partition %s is not in the cache", key)
@@ -198,7 +198,7 @@ func (c *lru) getFromCompressedCache(key string) (value itypes.ReduceablePartiti
 		if err != nil {
 			panic(err)
 		}
-		log.Printf("Loaded partition %s from compressed memory", key)
+		// log.Printf("Loaded partition %s from compressed memory", key)
 		return decompressedPart, nil
 	}
 	return nil, fmt.Errorf("Partition %s is not in the cache", key)
@@ -233,7 +233,7 @@ func (c *lru) getFromDisk(key string) (value itypes.ReduceablePartition, err err
 	if err != nil {
 		panic(err)
 	}
-	log.Printf("Loaded partition %s from disk", key)
+	// log.Printf("Loaded partition %s from disk", key)
 	return part, nil
 }
 
@@ -242,9 +242,9 @@ func (c *lru) Resize(size int) {
 }
 
 func (c *lru) evictToCompressedMemory() {
-	log.Printf("Starting uncompressed memory evictor")
+	// log.Printf("Starting uncompressed memory evictor")
 	for msg := range c.toCompressed {
-		log.Printf("Swapping partition %s to compressed memory", msg.key)
+		// log.Printf("Swapping partition %s to compressed memory", msg.key)
 		buff, err := msg.value.ToBytes()
 		if err != nil {
 			log.Fatalf("Unable to convert partition to buffer %s", err)
@@ -296,9 +296,9 @@ func (c *lru) evictToCompressedMemory() {
 }
 
 func (c *lru) evictToDisk() {
-	log.Printf("Starting compressed memory evictor")
+	// log.Printf("Starting compressed memory evictor")
 	for msg := range c.toDisk {
-		log.Printf("Swapping partition %s to disk", msg.key)
+		// log.Printf("Swapping partition %s to disk", msg.key)
 		tempFilePath := path.Join(c.tmpDir, msg.key)
 		f, err := os.Create(tempFilePath)
 		if err != nil {

--- a/internal/pcache/doc.go
+++ b/internal/pcache/doc.go
@@ -1,0 +1,2 @@
+// Package pcache contains an implementation of an LRU cache for Partitions
+package pcache

--- a/internal/pcache/types.go
+++ b/internal/pcache/types.go
@@ -1,0 +1,13 @@
+package pcache
+
+import (
+	itypes "github.com/go-sif/sif/internal/types"
+)
+
+// PartitionCache is a cache for Partitions
+type PartitionCache interface {
+	Destroy()
+	Add(key string, value itypes.ReduceablePartition)
+	Get(key string) (value itypes.ReduceablePartition, err error) // removes the partition from the cache and returns it, if present. Returns an error otherwise.
+	Resize(size int)
+}

--- a/internal/types/partition.go
+++ b/internal/types/partition.go
@@ -31,6 +31,7 @@ type ReduceablePartition interface {
 	CloneablePartition
 	sif.BuildablePartition
 	sif.KeyablePartition
+	PopulateTempRow(tempRow sif.Row, idx int)
 	FindFirstKey(key uint64) (int, error)                                              // PRECONDITION: Partition must already be sorted by key
 	FindLastKey(key uint64) (int, error)                                               // PRECONDITION: Partition must already be sorted by key
 	FindFirstRowKey(keyBuf []byte, key uint64, keyfn sif.KeyingOperation) (int, error) // PRECONDITION: Partition must already be sorted by key

--- a/internal/types/plan_executor_config.go
+++ b/internal/types/plan_executor_config.go
@@ -2,8 +2,9 @@ package types
 
 // PlanExecutorConfig configures the execution of a plan
 type PlanExecutorConfig struct {
-	TempFilePath       string // the directory to use as on-disk swap space for partitions
-	InMemoryPartitions int    // the number of partitions to retain in memory before swapping to disk
-	Streaming          bool   // whether or not this executor is operating on streaming data
-	IgnoreRowErrors    bool   // iff true, log row transformation errors instead of crashing immediately
+	TempFilePath             string  // the directory to use as on-disk swap space for partitions
+	InMemoryPartitions       int     // the number of partitions to retain in memory before swapping to disk
+	CompressedMemoryFraction float32 // the percentage of in-memory partitions to compress before swapping to disk
+	Streaming                bool    // whether or not this executor is operating on streaming data
+	IgnoreRowErrors          bool    // iff true, log row transformation errors instead of crashing immediately
 }

--- a/operations/transform/reduce.go
+++ b/operations/transform/reduce.go
@@ -1,8 +1,6 @@
 package transform
 
 import (
-	"fmt"
-
 	"github.com/cespare/xxhash/v2"
 	"github.com/go-sif/sif"
 	itypes "github.com/go-sif/sif/internal/types"
@@ -23,7 +21,7 @@ func (s *reduceTask) RunWorker(previous sif.OperablePartition) ([]sif.OperablePa
 	// Start by keying the rows in the partition
 	part, err := previous.KeyRows(s.kfn)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to key rows: %e", err)
+		return nil, err
 	}
 	return []sif.OperablePartition{part}, nil
 }


### PR DESCRIPTION
- Custom partition LRU cache to replace https://github.com/hashicorp/golang-lru
- Cache is partitioned, including an in-memory uncompressed, in-memory compressed and on-disk component, allowing for flexible balancing of these three portions. Compressed memory allows more partitions to fit in-memory before having to swap to disk.
- Compression algorithm has been switched from lz4 to zstandard for superior compression ratios while retaining relevant throughput
- EDSM test has been switched to output multiple images to stress test the partition tree and new cache implementation