### PR TITLE
Memory limits should be measured in bytes, not # of partitions

### DIFF
--- a/cluster/coordinator.go
+++ b/cluster/coordinator.go
@@ -117,10 +117,11 @@ func (c *coordinator) Run(ctx context.Context) (*Result, error) {
 	}
 	log.Printf("Running job...")
 	statsTracker := &stats.RunStatistics{}
-	planExecutor := eframe.Optimize().Execute(&itypes.PlanExecutorConfig{
-		TempFilePath:       "",
-		InMemoryPartitions: 0,
-		Streaming:          c.frame.GetDataSource().IsStreaming(),
+	planExecutor := eframe.Optimize().Execute(ctx, &itypes.PlanExecutorConfig{
+		TempFilePath:             "",
+		CacheMemoryHighWatermark: c.opts.CacheMemoryHighWatermark,
+		CompressedCacheFraction:  c.opts.CompressedCacheFraction,
+		Streaming:                c.frame.GetDataSource().IsStreaming(),
 	}, statsTracker)
 	statsTracker.Start(planExecutor.GetNumStages())
 	defer statsTracker.Finish()

--- a/internal/dataframe/partition_iterator.go
+++ b/internal/dataframe/partition_iterator.go
@@ -186,9 +186,9 @@ type pTreePartitionIterator struct {
 
 func createPTreeIterator(tree *pTreeRoot, destructive bool) sif.PartitionIterator {
 	if tree == nil {
-		return &pTreePartitionIterator{next: nil, destructive: destructive, endListeners: []func(){tree.clearCaches}}
+		return &pTreePartitionIterator{next: nil, destructive: destructive, endListeners: []func(){}}
 	}
-	return &pTreePartitionIterator{next: tree.firstNode(), destructive: destructive, endListeners: []func(){tree.clearCaches}}
+	return &pTreePartitionIterator{next: tree.firstNode(), destructive: destructive, endListeners: []func(){}}
 }
 
 // OnEnd registers a listener which fires when this iterator runs out of Partitions

--- a/internal/dataframe/partition_tree_test.go
+++ b/internal/dataframe/partition_tree_test.go
@@ -44,7 +44,7 @@ func pTreeTestKeyer(row sif.Row) ([]byte, error) {
 
 func TestCreatePartitionTree(t *testing.T) {
 	schema := createPTreeTestSchema()
-	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), InMemoryPartitions: 20}
+	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), CacheMemoryInitialSize: 20}
 	root := createPTreeNode(conf, 3, schema)
 	defer root.clearCaches()
 
@@ -63,7 +63,7 @@ func TestCreatePartitionTree(t *testing.T) {
 
 func TestMergeRow(t *testing.T) {
 	schema := createPTreeTestSchema()
-	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), InMemoryPartitions: 20}
+	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), CacheMemoryInitialSize: 20}
 	root := createPTreeNode(conf, 3, schema)
 	defer root.clearCaches()
 
@@ -140,7 +140,7 @@ func TestMergeRow(t *testing.T) {
 
 func TestMergeRowWithSplit(t *testing.T) {
 	schema := createPTreeTestSchema()
-	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), InMemoryPartitions: 20}
+	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), CacheMemoryInitialSize: 20}
 	root := createPTreeNode(conf, 3, schema)
 	defer root.clearCaches()
 
@@ -169,7 +169,7 @@ func TestMergeRowWithSplit(t *testing.T) {
 
 func TestMergeRowWithRotate(t *testing.T) {
 	schema := createPTreeTestSchema()
-	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), InMemoryPartitions: 20}
+	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), CacheMemoryInitialSize: 20}
 	root := createPTreeNode(conf, 3, schema)
 	defer root.clearCaches()
 	tempRow := partition.CreateTempRow()
@@ -232,7 +232,7 @@ func TestDiskSwap(t *testing.T) {
 		return nil
 	}
 
-	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), InMemoryPartitions: 5}
+	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), CacheMemoryInitialSize: 5}
 	// each partition can store 2 rows
 	root := createPTreeNode(conf, 2, schema)
 	defer root.clearCaches()
@@ -270,7 +270,7 @@ func TestPartitionIterationDuringReduction(t *testing.T) {
 		return nil
 	}
 
-	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), InMemoryPartitions: 5}
+	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), CacheMemoryInitialSize: 5}
 	// each partition can store 2 rows
 	root := createPTreeNode(conf, 2, schema)
 	defer root.clearCaches()
@@ -309,7 +309,7 @@ func TestPartitionIterationDuringRepartition(t *testing.T) {
 	schema.CreateColumn("key", &sif.Uint32ColumnType{})
 	schema.CreateColumn("val", &sif.Uint32ColumnType{})
 
-	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), InMemoryPartitions: 10, CompressedMemoryFraction: 0.75}
+	conf := &itypes.PlanExecutorConfig{TempFilePath: os.TempDir(), CacheMemoryInitialSize: 10, CompressedCacheFraction: 0.75}
 	// each partition can store 2 rows
 	root := createPTreeNode(conf, 2, schema)
 	defer root.clearCaches()

--- a/internal/dataframe/plan.go
+++ b/internal/dataframe/plan.go
@@ -1,6 +1,8 @@
 package dataframe
 
 import (
+	"context"
+
 	"github.com/go-sif/sif"
 	"github.com/go-sif/sif/internal/stats"
 	itypes "github.com/go-sif/sif/internal/types"
@@ -34,6 +36,6 @@ func (p *planImpl) Source() sif.DataSource {
 }
 
 // Execute creates a planExecutor for this Plan
-func (p *planImpl) Execute(conf *itypes.PlanExecutorConfig, statsTracker *stats.RunStatistics) itypes.PlanExecutor {
-	return CreatePlanExecutor(p, conf, statsTracker)
+func (p *planImpl) Execute(ctx context.Context, conf *itypes.PlanExecutorConfig, statsTracker *stats.RunStatistics) itypes.PlanExecutor {
+	return CreatePlanExecutor(ctx, p, conf, statsTracker)
 }

--- a/internal/pcache/types.go
+++ b/internal/pcache/types.go
@@ -9,5 +9,6 @@ type PartitionCache interface {
 	Destroy()
 	Add(key string, value itypes.ReduceablePartition)
 	Get(key string) (value itypes.ReduceablePartition, err error) // removes the partition from the cache and returns it, if present. Returns an error otherwise.
-	Resize(size int)
+	CurrentSize() int
+	Resize(frac float64)
 }

--- a/internal/test/integration/edsm_test.go
+++ b/internal/test/integration/edsm_test.go
@@ -182,6 +182,6 @@ func TestEDSMHeatmap(t *testing.T) {
 	require.Nil(t, err)
 
 	// run dataframe and verify results
-	_, err = siftest.LocalRunFrame(context.Background(), frame, &cluster.NodeOptions{NumInMemoryPartitions: 16}, 2)
+	_, err = siftest.LocalRunFrame(context.Background(), frame, &cluster.NodeOptions{CacheMemoryHighWatermark: 85 * 1024 * 1024}, 2)
 	require.Nil(t, err)
 }

--- a/internal/test/integration/nyc_taxi_test.go
+++ b/internal/test/integration/nyc_taxi_test.go
@@ -178,7 +178,7 @@ func TestNYCTaxi(t *testing.T) {
 	require.Nil(t, err)
 
 	// run dataframe and verify results
-	res, err := siftest.LocalRunFrame(context.Background(), frame, &cluster.NodeOptions{NumInMemoryPartitions: 20}, 2)
+	res, err := siftest.LocalRunFrame(context.Background(), frame, &cluster.NodeOptions{CacheMemoryHighWatermark: 64 * 1024 * 1024}, 2)
 	require.Nil(t, err)
 	require.NotNil(t, res)
 

--- a/internal/types/plan.go
+++ b/internal/types/plan.go
@@ -1,15 +1,17 @@
 package types
 
 import (
+	"context"
+
 	"github.com/go-sif/sif"
 	"github.com/go-sif/sif/internal/stats"
 )
 
 // A Plan is an execution plan for a DataFrame
 type Plan interface {
-	Size() int                                                                        // returns the number of stages
-	GetStage(idx int) Stage                                                           // GetStage returns a particular Stage in this Plan
-	Parser() sif.DataSourceParser                                                     // Parser returns this Plan's DataSourceParser
-	Source() sif.DataSource                                                           // Source returns this Plan's DataSource
-	Execute(conf *PlanExecutorConfig, statsTracker *stats.RunStatistics) PlanExecutor // Creates a PlanExecutor given a particular configuration
+	Size() int                                                                                             // returns the number of stages
+	GetStage(idx int) Stage                                                                                // GetStage returns a particular Stage in this Plan
+	Parser() sif.DataSourceParser                                                                          // Parser returns this Plan's DataSourceParser
+	Source() sif.DataSource                                                                                // Source returns this Plan's DataSource
+	Execute(ctx context.Context, conf *PlanExecutorConfig, statsTracker *stats.RunStatistics) PlanExecutor // Creates a PlanExecutor given a particular configuration
 }

--- a/internal/types/plan_executor_config.go
+++ b/internal/types/plan_executor_config.go
@@ -2,9 +2,11 @@ package types
 
 // PlanExecutorConfig configures the execution of a plan
 type PlanExecutorConfig struct {
+	NumWorkers               int
 	TempFilePath             string  // the directory to use as on-disk swap space for partitions
-	InMemoryPartitions       int     // the number of partitions to retain in memory before swapping to disk
-	CompressedMemoryFraction float32 // the percentage of in-memory partitions to compress before swapping to disk
+	CacheMemoryInitialSize   int     // The initial size of the partition cache, measured in partitions
+	CacheMemoryHighWatermark uint64  // soft memory limit for in-memory partition caches, in bytes
+	CompressedCacheFraction  float32 // the percentage of in-memory partitions to compress before swapping to disk
 	Streaming                bool    // whether or not this executor is operating on streaming data
 	IgnoreRowErrors          bool    // iff true, log row transformation errors instead of crashing immediately
 }

--- a/testing/test_runner.go
+++ b/testing/test_runner.go
@@ -30,8 +30,8 @@ func LocalRunFrame(ctx context.Context, frame sif.DataFrame, opts *cluster.NodeO
 	opts.NumWorkers = numWorkers
 	opts.WorkerJoinTimeout = time.Duration(5) * time.Second
 	opts.RPCTimeout = time.Duration(5) * time.Second
-	if opts.NumInMemoryPartitions == 0 {
-		opts.NumInMemoryPartitions = 10
+	if opts.CacheMemoryHighWatermark == 0 {
+		opts.CacheMemoryHighWatermark = 512 * 1024 * 1024
 	}
 
 	coordinator, err := cluster.CreateNodeInRole(cluster.Coordinator, opts)


### PR DESCRIPTION
Partition size will vary between stages, so measuring cache size in # of partitions leads to an inefficient use of memory for stages with smaller partitions.