### PR TITLE
Documenting Schema interface

### DIFF
--- a/accumulators/sum.go
+++ b/accumulators/sum.go
@@ -28,7 +28,7 @@ func (a *Sum) GetSum() float64 {
 
 // Accumulate adds a row to this Accumulator
 func (a *Sum) Accumulate(row sif.Row) error {
-	offset, err := row.Schema().GetOffset(a.colName)
+	offset, err := row.Schema().GetColumn(a.colName)
 	if err != nil {
 		return err
 	}

--- a/internal/partition/partition-reduceable.go
+++ b/internal/partition/partition-reduceable.go
@@ -270,7 +270,7 @@ func (p *partitionImpl) ToBytes() ([]byte, error) {
 				svrd[k].RowData[uint32(i)] = nil
 				continue
 			}
-			if col, err := p.schema.GetOffset(k); err == nil {
+			if col, err := p.schema.GetColumn(k); err == nil {
 				if vcol, ok := col.Type().(sif.VarColumnType); ok {
 					sdata, err := vcol.Serialize(v)
 					if err != nil {

--- a/internal/partition/row-accessible.go
+++ b/internal/partition/row-accessible.go
@@ -29,7 +29,7 @@ func (r *rowImpl) GetSchema() sif.Schema {
 
 // GetColData retrives raw bytes for a column
 func (r *rowImpl) GetColData(colName string) ([]byte, error) {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/partition/row.go
+++ b/internal/partition/row.go
@@ -74,7 +74,7 @@ func (r *rowImpl) ToString() string {
 
 // IsNil returns true iff the given column value is nil in this row. If an error occurs, this function will return false.
 func (r *rowImpl) IsNil(colName string) bool {
-	offset, e := r.schema.GetOffset(colName)
+	offset, e := r.schema.GetColumn(colName)
 	if e != nil {
 		return false
 	}
@@ -87,7 +87,7 @@ func (r *rowImpl) IsNil(colName string) bool {
 
 // SetNil sets the given column value to nil within this row
 func (r *rowImpl) SetNil(colName string) error {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (r *rowImpl) SetNotNil(offset sif.Column) {
 
 // Get returns the value of any column as an interface{}, if it exists
 func (r *rowImpl) Get(colName string) (col interface{}, err error) {
-	offset, err := r.Schema().GetOffset(colName)
+	offset, err := r.Schema().GetColumn(colName)
 	if err != nil {
 		return nil, err
 	} else if sif.IsVariableLength(offset.Type()) {
@@ -172,7 +172,7 @@ func (r *rowImpl) Get(colName string) (col interface{}, err error) {
 
 // GetByte retrieves a single byte from the column with the given name.
 func (r *rowImpl) GetByte(colName string) (col byte, err error) {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return
 	}
@@ -186,7 +186,7 @@ func (r *rowImpl) GetByte(colName string) (col byte, err error) {
 
 // GetBytes retrieves a multiple byte from the column with the given name.
 func (r *rowImpl) GetBytes(colName string) (col []byte, err error) {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return
 	}
@@ -200,7 +200,7 @@ func (r *rowImpl) GetBytes(colName string) (col []byte, err error) {
 
 // GetBool retrieves a single bool from the column with the given name.
 func (r *rowImpl) GetBool(colName string) (col bool, err error) {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return
 	}
@@ -214,7 +214,7 @@ func (r *rowImpl) GetBool(colName string) (col bool, err error) {
 
 // GetUint8 retrieves a single uint8 from the column with the given name.
 func (r *rowImpl) GetUint8(colName string) (col uint8, err error) {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return
 	}
@@ -228,7 +228,7 @@ func (r *rowImpl) GetUint8(colName string) (col uint8, err error) {
 
 // GetUint16 retrieves a single uint16 from the column with the given name
 func (r *rowImpl) GetUint16(colName string) (col uint16, err error) {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return
 	}
@@ -242,7 +242,7 @@ func (r *rowImpl) GetUint16(colName string) (col uint16, err error) {
 
 // GetUint32 retrieves a single uint32 from the column with the given name
 func (r *rowImpl) GetUint32(colName string) (col uint32, err error) {
-	offset, e := r.schema.GetOffset(colName)
+	offset, e := r.schema.GetColumn(colName)
 	if e != nil {
 		err = e
 		return
@@ -257,7 +257,7 @@ func (r *rowImpl) GetUint32(colName string) (col uint32, err error) {
 
 // GetUint64 retrieves a single uint64 from the column with the given name
 func (r *rowImpl) GetUint64(colName string) (col uint64, err error) {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return
 	}
@@ -271,7 +271,7 @@ func (r *rowImpl) GetUint64(colName string) (col uint64, err error) {
 
 // GetInt8 retrieves a single int8 from the column with the given name
 func (r *rowImpl) GetInt8(colName string) (col int8, err error) {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return
 	}
@@ -358,7 +358,7 @@ func (r *rowImpl) GetString(colName string) (string, error) {
 
 // GetVarCustomData retrieves variable-length data of a custom type from the column with the given name
 func (r *rowImpl) GetVarCustomData(colName string) (interface{}, error) {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +414,7 @@ func (r *rowImpl) GetVarString(colName string) (col string, err error) {
 
 // SetByte modifies a single byte from the column with the given name.
 func (r *rowImpl) SetByte(colName string, value byte) (err error) {
-	offset, e := r.schema.GetOffset(colName)
+	offset, e := r.schema.GetColumn(colName)
 	if e != nil {
 		err = e
 		return
@@ -426,7 +426,7 @@ func (r *rowImpl) SetByte(colName string, value byte) (err error) {
 
 // SetBytes overwrites multiple byte from the column with the given name.
 func (r *rowImpl) SetBytes(colName string, value []byte) (err error) {
-	offset, e := r.schema.GetOffset(colName)
+	offset, e := r.schema.GetColumn(colName)
 	if e != nil {
 		err = e
 		return
@@ -441,7 +441,7 @@ func (r *rowImpl) SetBytes(colName string, value []byte) (err error) {
 
 // SetBool modifies a single bool from the column with the given name.
 func (r *rowImpl) SetBool(colName string, value bool) (err error) {
-	offset, e := r.schema.GetOffset(colName)
+	offset, e := r.schema.GetColumn(colName)
 	if e != nil {
 		err = e
 		return
@@ -457,7 +457,7 @@ func (r *rowImpl) SetBool(colName string, value bool) (err error) {
 
 // SetUint8 modifies a single uint8 from the column with the given name.
 func (r *rowImpl) SetUint8(colName string, value uint8) (err error) {
-	offset, e := r.schema.GetOffset(colName)
+	offset, e := r.schema.GetColumn(colName)
 	if e != nil {
 		err = e
 		return
@@ -469,7 +469,7 @@ func (r *rowImpl) SetUint8(colName string, value uint8) (err error) {
 
 // SetUint16 modifies a single uint16 from the column with the given name.
 func (r *rowImpl) SetUint16(colName string, value uint16) (err error) {
-	offset, e := r.schema.GetOffset(colName)
+	offset, e := r.schema.GetColumn(colName)
 	if e != nil {
 		err = e
 		return
@@ -483,7 +483,7 @@ func (r *rowImpl) SetUint16(colName string, value uint16) (err error) {
 
 // SetUint32 modifies a single uint32 from the column with the given name.
 func (r *rowImpl) SetUint32(colName string, value uint32) (err error) {
-	offset, e := r.schema.GetOffset(colName)
+	offset, e := r.schema.GetColumn(colName)
 	if e != nil {
 		err = e
 		return
@@ -497,7 +497,7 @@ func (r *rowImpl) SetUint32(colName string, value uint32) (err error) {
 
 // SetUint64 modifies a single uint64 from the column with the given name.
 func (r *rowImpl) SetUint64(colName string, value uint64) (err error) {
-	offset, e := r.schema.GetOffset(colName)
+	offset, e := r.schema.GetColumn(colName)
 	if e != nil {
 		err = e
 		return
@@ -556,7 +556,7 @@ func (r *rowImpl) SetString(colName string, value string) (err error) {
 
 // SetVarCustomData stores variable-length data of a custom type in this Row
 func (r *rowImpl) SetVarCustomData(colName string, value interface{}) (err error) {
-	offset, err := r.schema.GetOffset(colName)
+	offset, err := r.schema.GetColumn(colName)
 	if err != nil {
 		return
 	}
@@ -590,7 +590,7 @@ func (r *rowImpl) Repack(newSchema sif.Schema) (sif.Row, error) {
 			return nil
 		}
 		// otherwise, copy old values
-		oldCol, err := r.schema.GetOffset(name)
+		oldCol, err := r.schema.GetColumn(name)
 		if err != nil {
 			return err
 		}

--- a/schema.go
+++ b/schema.go
@@ -4,22 +4,22 @@ package sif
 // within a Row. It allows one to obtain offsets by name,
 // define new columns, remove columns, etc.
 type Schema interface {
-	Equals(otherSchema Schema) error
-	Clone() Schema
-	RowWidth() int // does not include padding - this is the size of the data which literally represents the row
-	Size() int     // includes padding - this is the size of the data actually stored for a row
-	NumColumns() int
-	NumFixedLengthColumns() int
-	NumVariableLengthColumns() int
-	NumRemovedColumns() int
-	Repack() (newSchema Schema)
-	GetOffset(colName string) (offset Column, err error)
-	HasColumn(colName string) bool
-	CreateColumn(colName string, columnType ColumnType) (newSchema Schema, err error)
-	RenameColumn(oldName string, newName string) (newSchema Schema, err error)
-	RemoveColumn(colName string) (newSchema Schema, wasRemoved bool)
-	IsMarkedForRemoval(colName string) bool
-	ColumnNames() []string
-	ColumnTypes() []ColumnType
-	ForEachColumn(fn func(name string, col Column) error) error
+	Equals(otherSchema Schema) error                                                  // Equals return true iff this Schema is identical to otherSchema
+	Clone() Schema                                                                    // Clone() returns a deep copy of this Schema
+	RowWidth() int                                                                    // RowWidth returns the total size of the data required to store a Row respecting this Schema (not including padding). Includes removed columns.
+	Size() int                                                                        // Size returns the total size of the data required to store a Row respecting this Schema (including padding). Includes removed columns.
+	NumColumns() int                                                                  // NumColumns returns the number of columns in this Schema. Includes removed columns.
+	NumFixedLengthColumns() int                                                       // NumFixedLengthColumns returns the number of fixed-length columns in this Schema. Includes removed columns.
+	NumVariableLengthColumns() int                                                    // NumVariableLengthColumns returns the number of variable-length columns in this Schema. Includes removed columns.
+	NumRemovedColumns() int                                                           // NumRemovedColumns returns the number of removed columns in this Schema
+	Repack() (newSchema Schema)                                                       // Repack optimizes the Schema, truly removing removed Columns
+	GetColumn(colName string) (offset Column, err error)                              // GetColumn returns the Column associated with colName, or an error if none exists
+	HasColumn(colName string) bool                                                    // HasColumn returns true iff colName corresponds to a Column in this Schema
+	CreateColumn(colName string, columnType ColumnType) (newSchema Schema, err error) // CreateColumn defines a new Column in this Schema
+	RenameColumn(oldName string, newName string) (newSchema Schema, err error)        // RenameColumn renames a Column in this Schema, returning a reference to this Schema
+	RemoveColumn(colName string) (newSchema Schema, wasRemoved bool)                  // RemoveColumn marks a Column for removal during the next Repack(), but does not actually remove it
+	IsMarkedForRemoval(colName string) bool                                           // IsMarkedForRemoval returns true iff the Column corresponding to colName exists and has been Remove()d
+	ColumnNames() []string                                                            // ColumnNames returns a list of Column names in this Schema, in the order they were created
+	ColumnTypes() []ColumnType                                                        // ColumnTypes returns a list of Column types in this Schema, in the order they were created
+	ForEachColumn(fn func(name string, col Column) error) error                       // ForEachColumn runs a function for each Column in this Schema
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -75,7 +75,7 @@ func (s *schema) Equals(otherSchema sif.Schema) error {
 		return fmt.Errorf("Schemas have unequal numbers of variable-length columns")
 	}
 	return s.ForEachColumn(func(name string, offset sif.Column) error {
-		otherOffset, err := otherSchema.GetOffset(name)
+		otherOffset, err := otherSchema.GetColumn(name)
 		if err != nil {
 			return err
 		}
@@ -182,8 +182,8 @@ func (s *schema) Repack() (newSchema sif.Schema) {
 	return
 }
 
-// GetOffset returns the byte offset of a particular column within a row.
-func (s *schema) GetOffset(colName string) (offset sif.Column, err error) {
+// GetColumn returns the byte offset of a particular column within a row.
+func (s *schema) GetColumn(colName string) (offset sif.Column, err error) {
 	offset, ok := s.schema[colName]
 	if !ok {
 		err = fmt.Errorf("Schema does not contain column with name %s", colName)
@@ -193,7 +193,7 @@ func (s *schema) GetOffset(colName string) (offset sif.Column, err error) {
 
 // HasColumn returns true iff this schema contains a column with the given name
 func (s *schema) HasColumn(colName string) bool {
-	_, err := s.GetOffset(colName)
+	_, err := s.GetColumn(colName)
 	return err == nil
 }
 
@@ -219,7 +219,7 @@ func (s *schema) RenameColumn(oldName string, newName string) (newSchema sif.Sch
 	if s.IsMarkedForRemoval(oldName) {
 		return nil, fmt.Errorf("Cannot rename removed column %s", oldName)
 	}
-	_, err = s.GetOffset(oldName)
+	_, err = s.GetColumn(oldName)
 	if err == nil {
 		s.schema[newName] = s.schema[oldName]
 		delete(s.schema, oldName)


### PR DESCRIPTION
Documenting `Schema` interface. Renaming `GetOffset` to `GetColumn` for the sake of consistency.