### PR TITLE
Only search the relevant subtree when merging all rows in a Partition into a ptree

### DIFF
--- a/internal/pindex/bucketed/bucketed_partition_index.go
+++ b/internal/pindex/bucketed/bucketed_partition_index.go
@@ -48,7 +48,7 @@ func (b *bucketed) GetNextStageSchema() sif.Schema {
 	return b.nextStageSchema
 }
 
-func (b *bucketed) ReducePartition(part sif.ReduceablePartition, keyfn sif.KeyingOperation, reducefn sif.ReductionOperation) error {
+func (b *bucketed) MergePartition(part sif.ReduceablePartition, keyfn sif.KeyingOperation, reducefn sif.ReductionOperation) error {
 	var multierr *multierror.Error
 	// merge rows into our trees
 	i := 0
@@ -75,10 +75,6 @@ func (b *bucketed) ReducePartition(part sif.ReduceablePartition, keyfn sif.Keyin
 		return err
 	}
 	return multierr.ErrorOrNil()
-}
-
-func (b *bucketed) MergePartition(part sif.BuildablePartition, keyfn sif.KeyingOperation, reducefn sif.ReductionOperation) error {
-	panic("not implemented") // TODO: Implement
 }
 
 func (b *bucketed) MergeRow(tempRow sif.Row, row sif.Row, keyfn sif.KeyingOperation, reducefn sif.ReductionOperation) error {

--- a/internal/pindex/hashmap/partition_map.go
+++ b/internal/pindex/hashmap/partition_map.go
@@ -28,8 +28,8 @@ func (m *pMap) GetNextStageSchema() sif.Schema {
 	return m.nextStageSchema
 }
 
-func (m *pMap) MergePartition(part sif.BuildablePartition, keyfn sif.KeyingOperation, reducefn sif.ReductionOperation) error {
-	m.cache.Add(part.ID(), part.(sif.ReduceablePartition))
+func (m *pMap) MergePartition(part sif.ReduceablePartition, keyfn sif.KeyingOperation, reducefn sif.ReductionOperation) error {
+	m.cache.Add(part.ID(), part)
 	m.ids = append(m.ids, part.ID())
 	return nil
 }

--- a/operations/transform/reduce.go
+++ b/operations/transform/reduce.go
@@ -82,8 +82,8 @@ func (s *reduceTask) RunWorker(sctx sif.StageContext, previous sif.OperableParti
 		rpart = repackedPart.(sif.ReduceablePartition)
 	}
 	// merge partition into the index
-	bpi, _ := sctx.PartitionIndex().(sif.BucketedPartitionIndex) // we know this is a safe access and cast because we're setting this ourselves and it can't be changed once set
-	err = bpi.ReducePartition(rpart, sctx.KeyingOperation(), sctx.ReductionOperation())
+	pi := sctx.PartitionIndex()
+	err = pi.MergePartition(rpart, sctx.KeyingOperation(), sctx.ReductionOperation())
 	if err != nil {
 		return nil, err
 	}

--- a/partition_index.go
+++ b/partition_index.go
@@ -6,21 +6,20 @@ package sif
 // in a particular order unique to the implementation (e.g. sorted order for an index which sorts Rows).
 // Leverages an underlying PartitionCache for Partition storage, rather than storing Partition data itself.
 type PartitionIndex interface {
-	SetMaxRows(maxRows int)                                                                           // Change the maxRows for future partitions created by this index
-	GetNextStageSchema() Schema                                                                       // Returns the Schema for the Stage which will *read* from this index
-	MergePartition(part BuildablePartition, keyfn KeyingOperation, reducefn ReductionOperation) error // Merges all the Rows within a Partition into this PartitionIndex. reducefn may be nil, indicating that reduction is not intended.
-	MergeRow(tempRow Row, row Row, keyfn KeyingOperation, reducefn ReductionOperation) error          // Merges a Row of data into the PartitionIndex, possibly appending it to an existing/new Partition, or combining it with an existing Row. reducefn may be nil, indicating that reduction is not intended.
-	GetPartitionIterator(destructive bool) PartitionIterator                                          // Returns the PartitionIterator for this PartitionIndex. Must always return the same PartitionIterator, even if called multiple times.
-	GetSerializedPartitionIterator(destructive bool) SerializedPartitionIterator                      // Returns a SerializedPartitionIterator for this PartitionIndex. Must always return the same SerializedPartitionIterator, even if called multiple times.
-	NumPartitions() uint64                                                                            // Returns the number of Partitions in this PartitionIndex
-	CacheSize() int                                                                                   // Returns the in-memory size (in Partitions) of the underlying PartitionCache
-	ResizeCache(frac float64) bool                                                                    // Resizes the underlying PartitionCache
-	Destroy()                                                                                         // Destroys the index
+	SetMaxRows(maxRows int)                                                                            // Change the maxRows for future partitions created by this index
+	GetNextStageSchema() Schema                                                                        // Returns the Schema for the Stage which will *read* from this index
+	MergePartition(part ReduceablePartition, keyfn KeyingOperation, reducefn ReductionOperation) error // Merges all the Rows within a Partition into this PartitionIndex. reducefn may be nil, indicating that reduction is not intended.
+	MergeRow(tempRow Row, row Row, keyfn KeyingOperation, reducefn ReductionOperation) error           // Merges a Row of data into the PartitionIndex, possibly appending it to an existing/new Partition, or combining it with an existing Row. reducefn may be nil, indicating that reduction is not intended.
+	GetPartitionIterator(destructive bool) PartitionIterator                                           // Returns the PartitionIterator for this PartitionIndex. Must always return the same PartitionIterator, even if called multiple times.
+	GetSerializedPartitionIterator(destructive bool) SerializedPartitionIterator                       // Returns a SerializedPartitionIterator for this PartitionIndex. Must always return the same SerializedPartitionIterator, even if called multiple times.
+	NumPartitions() uint64                                                                             // Returns the number of Partitions in this PartitionIndex
+	CacheSize() int                                                                                    // Returns the in-memory size (in Partitions) of the underlying PartitionCache
+	ResizeCache(frac float64) bool                                                                     // Resizes the underlying PartitionCache
+	Destroy()                                                                                          // Destroys the index
 }
 
 // A BucketedPartitionIndex is a PartitionIndex divided into buckets, which are indexed by uint64s
 type BucketedPartitionIndex interface {
 	PartitionIndex
-	GetBucket(bucket uint64) PartitionIndex                                                             // return the PartitionIndex associated with the given bucket
-	ReducePartition(part ReduceablePartition, keyfn KeyingOperation, reducefn ReductionOperation) error // Merge rows from an already-keyed partition into the appropriate buckets
+	GetBucket(bucket uint64) PartitionIndex // return the PartitionIndex associated with the given bucket
 }


### PR DESCRIPTION
Also, bringing `BucketedPartitionIndex` closer to `PartitionIndex` by eliminating similarly-named and similarly-intended method.